### PR TITLE
Fix imports for Gleam v1

### DIFF
--- a/src/filespy.gleam
+++ b/src/filespy.gleam
@@ -4,9 +4,9 @@
 ////
 //// Note: on Linux and BSD, you need `inotify-tools` installed.
 
-import gleam/option.{None, Option, Some}
-import gleam/otp/actor.{ErlangStartResult}
-import gleam/erlang/atom.{Atom}
+import gleam/option.{type Option, None, Some}
+import gleam/otp/actor.{type ErlangStartResult}
+import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process
 import gleam/dynamic
 import gleam/string


### PR DESCRIPTION
Some time between filespy being published and Gleam v1 we added the `type` import syntax. Currently filespy won't build on new Gleam projects, this PR fixes the imports!