### PR TITLE
allow use of gleam_stdlib 0.37.0

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,7 +1,11 @@
-{ pkgs, ... }:
-
-{
-  packages = with pkgs; [ rebar3 inotify-tools ];
+{pkgs, ...}: {
+  packages =
+    [pkgs.rebar3]
+    ++ (
+      if (!pkgs.stdenv.isDarwin)
+      then [pkgs.inotify-tools]
+      else [pkgs.darwin.apple_sdk.frameworks.CoreServices]
+    );
 
   languages.elixir.enable = true;
   languages.gleam.enable = true;

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "pta2002", repo = "gleam-filespy" }
 
 [dependencies]
-gleam_stdlib = "~> 0.36.0"
+gleam_stdlib = ">= 0.36.0 and <= 0.37.0"
 gleam_otp = "~> 0.10"
 gleam_erlang = "~> 0.25"
 fs = "~> 8.6"

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,5 +13,5 @@ packages = [
 fs = { version = "~> 8.6" }
 gleam_erlang = { version = "~> 0.25" }
 gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = "~> 0.36.0" }
+gleam_stdlib = { version = ">= 0.36.0 and <= 0.37.0" }
 gleeunit = { version = "~> 1.0.2" }


### PR DESCRIPTION
Gleam stdlib 0.37.0 has been released and with no breaking changes to filespy's functionality, the requirement can be updated to permit the newer version.

For the changelog see https://github.com/gleam-lang/stdlib/compare/v0.36.0...v0.37.0

I also adjusted the devenv.nix file to work on darwin.

I checked that this library still works with the newer version of the stdlib.