### PR TITLE
Adapt filespy to the new gleam stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "pta2002", repo = "gleam-filespy" }
 
 [dependencies]
-gleam_stdlib = ">= 0.36.0 and <= 0.37.0"
+gleam_stdlib = ">= 0.36.0 and < 2.0.0"
 gleam_otp = "~> 0.10"
 gleam_erlang = "~> 0.25"
 fs = "~> 8.6"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ packages = [
   { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
 ]
 
@@ -13,5 +13,5 @@ packages = [
 fs = { version = "~> 8.6" }
 gleam_erlang = { version = "~> 0.25" }
 gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = ">= 0.36.0 and <= 0.37.0" }
+gleam_stdlib = { version = ">= 0.36.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0.2" }

--- a/src/filespy.gleam
+++ b/src/filespy.gleam
@@ -4,15 +4,18 @@
 ////
 //// Note: on Linux and BSD, you need `inotify-tools` installed.
 
+import gleam/dynamic
+import gleam/erlang/atom.{type Atom}
+import gleam/erlang/charlist
+import gleam/erlang/process
+import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor.{type ErlangStartResult}
-import gleam/erlang/atom.{type Atom}
-import gleam/erlang/process
-import gleam/dynamic
-import gleam/string
-import gleam/erlang/charlist
 import gleam/result
-import gleam/list
+import gleam/string
+
+@external(erlang, "filespy_ffi", "identity")
+fn coerce(value: a) -> b
 
 /// Phantom type to indicate the Builder has no directories
 pub type NoDirectories
@@ -79,7 +82,7 @@ pub fn new() -> Builder(a, NoDirectories, NoHandler, NoInitialState, Nil) {
 /// Add a directory to watch
 ///
 /// # Examples
-/// 
+///
 /// ```gleam
 /// filespy.new()
 /// |> filespy.add_dir("./watched")
@@ -229,7 +232,7 @@ pub fn selector() -> process.Selector(Change(custom)) {
       dynamic.dynamic,
       dynamic.tuple2(
         fn(l) {
-          dynamic.unsafe_coerce(l)
+          coerce(l)
           |> charlist.to_string
           |> Ok
         },

--- a/src/filespy_ffi.erl
+++ b/src/filespy_ffi.erl
@@ -1,0 +1,5 @@
+-module(filespy_ffi).
+-export([identity/1]).
+
+% Used in coercion.
+identity(X) -> X.


### PR DESCRIPTION
Instead of locking Filespy to a fixed version of the stdlib, this PR relax the requirement, to minimise the maintenance impact (for every stdlib release, it should be updated).

It also implements a new `identity` function to get rid of the deprecated comment from `unsafe_coerce` in `dynamic` and to stay future-proof.

If you're OK with this, I could update `radiate` just after.