### PR TITLE
Build for latest Gleam standard library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.0.0"
+          gleam-version: "1.9.1"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam format --check src test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           gleam-version: "1.9.1"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
+      - run: sudo apt update && sudo apt install -y inotify-tools
       - run: gleam format --check src test
       - run: gleam deps download
       - run: gleam test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
+# v0.6.0
+
+- Rewrite decoders, to adapt to `gleam/dynamic/decode`. `gleam_stdlib`
+  constraint becomes `0.50.0` at least to make sure `gleam/dynamic/decode`
+  is available.
+
+# v0.5.0
+
+- Adapt to latest standard lib.
+
 # v0.4.0
+
 - Add support for custom handler types (https://github.com/pta2002/gleam-filespy/pull/4)
 
 # v0.3.0
+
 - Add support for gleam 1.0

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "filespy"
-version = "0.5.0"
+version = "0.6.0"
 
 description = "Get notified of filesystem events in Gleam"
 licences = ["Apache-2.0"]

--- a/gleam.toml
+++ b/gleam.toml
@@ -13,3 +13,4 @@ gleam_stdlib = ">= 0.50.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.2 and < 2.0.0"
+simplifile = ">= 2.2.0 and < 3.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,10 +6,10 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "pta2002", repo = "gleam-filespy" }
 
 [dependencies]
-gleam_stdlib = ">= 0.36.0 and < 2.0.0"
-gleam_otp = "~> 0.10"
-gleam_erlang = "~> 0.25"
-fs = "~> 8.6"
+fs = ">= 8.6.0 and < 9.0.0"
+gleam_erlang = ">= 0.25.0 and < 1.0.0"
+gleam_otp = ">= 0.10.0 and < 1.0.0"
+gleam_stdlib = ">= 0.50.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0.2"
+gleeunit = ">= 1.0.2 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,15 +3,15 @@
 
 packages = [
   { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
+  { name = "gleam_stdlib", version = "0.57.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86EFACDF6460B8681E82752C5490F9630EC0F138F88A037DDCB241799AA8811F" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
-fs = { version = "~> 8.6" }
-gleam_erlang = { version = "~> 0.25" }
-gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = ">= 0.36.0 and < 2.0.0" }
-gleeunit = { version = "~> 1.0.2" }
+fs = { version = ">= 8.6.0 and < 9.0.0" }
+gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
+gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.50.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.2 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,11 +2,13 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "filepath", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "65F51013BCF78A603AFFD7992EF1CC6ECA96C74038EB48887F656DE44DBC1902" },
   { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
   { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
   { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
   { name = "gleam_stdlib", version = "0.57.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86EFACDF6460B8681E82752C5490F9630EC0F138F88A037DDCB241799AA8811F" },
   { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
 ]
 
 [requirements]
@@ -15,3 +17,4 @@ gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.50.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.2 and < 2.0.0" }
+simplifile = { version = ">= 2.2.0 and < 3.0.0" }

--- a/test/filespy_test.gleam
+++ b/test/filespy_test.gleam
@@ -1,12 +1,52 @@
+import filespy
+import gleam/erlang/atom
+import gleam/erlang/process
+import gleam/list
+import gleam/string
 import gleeunit
 import gleeunit/should
+import simplifile
 
 pub fn main() {
   gleeunit.main()
 }
 
-// gleeunit test functions end in `_test`
-pub fn hello_world_test() {
-  1
-  |> should.equal(1)
+/// Create a file, and try to read the events. Because file is created in /tmp,
+/// some few events can be triggered from different paths, notably xattrmod or
+/// deleted/removed.
+pub fn file_creation_test() {
+  use <- filespy_setup()
+  use path, event <- start_filespy()
+  let xattrmod = atom.create_from_string("xattrmod")
+  let xattrmod = filespy.Unknown(xattrmod)
+  [filespy.Created, xattrmod, filespy.Deleted, filespy.Modified]
+  |> list.contains(event)
+  |> should.be_true
+  path
+  |> string.contains("filespy")
+  |> should.be_true
+}
+
+fn filespy_setup(next: fn() -> process.Subject(filespy.Change(a))) -> Nil {
+  // Create the temporary directory to get events from, launch the
+  // filespy process & create file to trigger some fsevents events.
+  simplifile.create_directory_all("/tmp/filespy") |> should.be_ok
+  let filespy_process = next()
+  let _ = simplifile.create_file("/tmp/filespy/example.txt")
+
+  // Because fsevents is an async process, sleeping is required to make sure
+  // every events are correctly handled in the filespy handler.
+  process.sleep(1000)
+
+  // Terminate the filespy process & clean the temporary folder.
+  process.send_exit(process.subject_owner(filespy_process))
+  simplifile.delete("/tmp/filespy") |> should.be_ok
+}
+
+fn start_filespy(handler: fn(String, filespy.Event) -> Nil) {
+  filespy.new()
+  |> filespy.add_dir("/tmp/filespy")
+  |> filespy.set_handler(handler)
+  |> filespy.start()
+  |> should.be_ok
 }


### PR DESCRIPTION
Hi !

Because the standard lib changed, `filespy` is now outdated.
I rewrote the decoders, to adapt to new stdlib. As a matter of consequence, `gleam_stdlib` constraint is now `0.50.0` (otherwise `gleam/dynamic/decode` is not available).